### PR TITLE
Disable code signing

### DIFF
--- a/.github/workflows/update-checksums-file.yml
+++ b/.github/workflows/update-checksums-file.yml
@@ -45,6 +45,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_config_global: true
+        if: false
 
       # If there are no changes, this action will not create a pull request
       - name: Create or update pull request


### PR DESCRIPTION
Disable code signing as we don't need it, and we don't have it configured. Let's see if that solves the issue, and we have the workflow working in this repository to update the gradle wrapper hashes.